### PR TITLE
Update .clang-format to work around https://bugs.llvm.org/show_bug.cg…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@
   AllowShortLoopsOnASingleLine: false,
   AlwaysBreakBeforeMultilineStrings: true,
   AlwaysBreakAfterReturnType: None,
+  AlwaysBreakAfterDefinitionReturnType: None,
   AlwaysBreakTemplateDeclarations: true,
   BinPackArguments: false,
   BinPackParameters: true,


### PR DESCRIPTION
…i?id=42077

Legacy AlwaysBreakAfterDefinitionReturnType gets set in Mozilla style, turning off AlwaysBreakAfterReturnType will get turned back on by clang-format due to existence of Legacy setting